### PR TITLE
Fix generator options parsing

### DIFF
--- a/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V1506.java
+++ b/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V1506.java
@@ -119,7 +119,7 @@ public final class V1506 {
                 if ("flat".equalsIgnoreCase(generatorName)) {
                     data.setMap("generatorOptions", V1506.convert(generatorOptions == null ? "" : generatorOptions));
                 } else if ("buffet".equalsIgnoreCase(generatorName) && generatorOptions != null) {
-                    data.setMap("generatorOptions", JsonTypeUtil.convertJsonToNBT(new JsonMapType(GsonHelper.parse(generatorName, true), false)));
+                    data.setMap("generatorOptions", JsonTypeUtil.convertJsonToNBT(new JsonMapType(GsonHelper.parse(generatorOptions, true), false)));
                 }
                 return null;
             }


### PR DESCRIPTION
It was parsing the name (always "buffet") rather than the options as json