### PR TITLE
Copy NBT in upgrade data neighbor ticks

### DIFF
--- a/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2843.java
+++ b/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2843.java
@@ -35,7 +35,7 @@ public final class V2843 {
                         if (outOfBounds == null) {
                             outOfBounds = Types.NBT.createEmptyList();
                         }
-                        outOfBounds.addMap(tick);
+                        outOfBounds.addMap(tick.copy());
                     }
                 }
 


### PR DESCRIPTION
Avoids multiple references to the same NBT via different paths. Found via porting to Rust, the borrow checker wasn't very happy :)