### PR TITLE
Fix ConverterParticleToNBT.parseProperties

### DIFF
--- a/src/main/java/ca/spottedleaf/dataconverter/minecraft/converters/particle/ConverterParticleToNBT.java
+++ b/src/main/java/ca/spottedleaf/dataconverter/minecraft/converters/particle/ConverterParticleToNBT.java
@@ -56,27 +56,29 @@ public final class ConverterParticleToNBT {
             reader.expect('[');
             reader.skipWhitespace();
 
-            while (reader.canRead() && reader.peek() != ']') {
-                reader.skipWhitespace();
-
-                final String property = reader.readString();
-
-                reader.skipWhitespace();
-                reader.expect('=');
-                reader.skipWhitespace();
-
-                final String value = reader.readString();
-                ret.setString(property, value);
-
-                reader.skipWhitespace();
-                if (reader.canRead()) {
-                    if (reader.peek() != ',') {
-                        // invalid character or ']'
-                        break;
+            if (reader.canRead() && reader.peek() != ']') {
+                while (reader.canRead()) {
+                    final String property = reader.readString();
+    
+                    reader.skipWhitespace();
+                    reader.expect('=');
+                    reader.skipWhitespace();
+    
+                    final String value = reader.readString();
+                    ret.setString(property, value);
+    
+                    reader.skipWhitespace();
+                    if (reader.canRead()) {
+                        if (reader.peek() != ',') {
+                            // invalid character or ']'
+                            break;
+                        }
+    
+                        // skip ',' and move onto next entry
+                        reader.skip();
                     }
-
-                    // skip ',' and move onto next entry
-                    reader.peek();
+                    
+                    reader.skipWhitespace();
                 }
             }
 


### PR DESCRIPTION
- The old code was using `StringReader.peek()` in a place where it meant to be `StringReader.skip()`.
- The vanilla code allows a trailing comma, but only if there is no whitespace between it and the closing bracket, which is a bit weird. I think that's a bug and it shouldn't allow trailing commas, but if you disagree then only the first issue needs to be fixed.