### PR TITLE
Fix lodestone compass target conversion

### DIFF
--- a/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V3820.java
+++ b/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V3820.java
@@ -53,10 +53,10 @@ public final class V3820 {
                 components.remove("minecraft:lodestone_target");
                 components.setMap("minecraft:lodestone_tracker", oldTarget);
 
-                final Object pos = oldTarget.getMap("pos");
-                final Object dim = oldTarget.getMap("dimension");
+                final Object pos = oldTarget.getGeneric("pos");
+                final Object dim = oldTarget.getGeneric("dimension");
 
-                if (pos == null && dim == null) {
+                if (pos == null || dim == null) {
                     return null;
                 }
 


### PR DESCRIPTION
- The old code used `getMap` instead of `getGeneric`. This would actually cause problems since `dimension` is a string in practice.
- Changed `&&` to `||` to match vanilla behaviour. Not as important as both should be set anyway.