### PR TITLE
Remove old name Thrower data for converted item entities

### DIFF
--- a/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2514.java
+++ b/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2514.java
@@ -159,8 +159,8 @@ public final class V2514 {
 
     static void replaceUUIDMLTag(final MapType data, final String oldPath, final String newPath) {
         final int[] uuid = createUUIDFromLongs(data.getMap(oldPath), "M", "L");
+        data.remove(oldPath);
         if (uuid != null) {
-            data.remove(oldPath);
             data.setInts(newPath, uuid);
         }
     }


### PR DESCRIPTION
Related Mojira issue created (reproduced separately): https://report.bugs.mojang.com/servicedesk/customer/portal/2/MC-305352

Running a paper server. An item dropped on the ground from before 1.13 (so say 1.12.2). When loaded the following error is logged into the console.
```
[Server thread/WARN]: [ca.spottedleaf.moonrise.paper.PaperHooks] [ca.spottedleaf.moonrise.paper.PaperHooks] Serialization errors:
chunk@[-1488, 1166]:
  [1]: Failed to decode value '"ellisbrewer"' from field 'Thrower': Not a list
```

Item entities used to store the Thrower as a player name. Then on the 1.12 -> 1.13 update, they started storing as UUID L/M version. Though, searching the code, I cannot find a datafixer that dropped the old data.
https://minecraft.wiki/w/Java_Edition_1.13#:~:text=in%20each%20compound.-,thrower,-and

Then in the 1.15.2 -> 1.16 update. They convert the UUID L/M to the array of 4 Ints. (Data converter 2514)
https://minecraft.wiki/w/Java_Edition_1.16#:~:text=now%20much%20darker.-,uuids,-UUIDs%20stored%20in

Hence the issue of being Not a List. By my best figuring. The issue is that the EntityUUIDFix/V2514 is passing on the original name String, instead of removing it completely when it can't convert it to a modern UUID.

The solution proposed is to always remove the old data, regardless of whether a not null uuid was found. Reason it isn't already, is probably due to that data being lost. But the consequence is this error...